### PR TITLE
chore(with-expo-one-click-login): bump Para to 2.3.0

### DIFF
--- a/mobile/with-expo-one-click-login/ios/ParaOneClickLogin.xcodeproj/project.pbxproj
+++ b/mobile/with-expo-one-click-login/ios/ParaOneClickLogin.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/mobile/with-expo-one-click-login/ios/Podfile.lock
+++ b/mobile/with-expo-one-click-login/ios/Podfile.lock
@@ -73,7 +73,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.81.5)
   - hermes-engine/Pre-built (0.81.5)
   - OpenSSL-Universal (3.3.3001)
-  - para-react-native-wallet (2.1.0):
+  - para-react-native-wallet (2.3.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2402,7 +2402,7 @@ SPEC CHECKSUMS:
   FBLazyVector: e95a291ad2dadb88e42b06e0c5fb8262de53ec12
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172
   OpenSSL-Universal: 6082b0bf950e5636fe0d78def171184e2b3899c2
-  para-react-native-wallet: 1908f7aac580314f2eddda805e843c0f7b33073b
+  para-react-native-wallet: ba3f7945fa7e76493f7f5251961009a10b485611
   RCTDeprecation: 943572d4be82d480a48f4884f670135ae30bf990
   RCTRequired: 8f3cfc90cc25cf6e420ddb3e7caaaabc57df6043
   RCTTypeSafety: 16a4144ca3f959583ab019b57d5633df10b5e97c

--- a/mobile/with-expo-one-click-login/package.json
+++ b/mobile/with-expo-one-click-login/package.json
@@ -15,8 +15,8 @@
   "dependencies": {
     "@craftzdog/react-native-buffer": "^6.1.0",
     "@expo/vector-icons": "^15.0.2",
-    "@getpara/react-native-wallet": "2.2.0",
-    "@getpara/viem-v2-integration": "2.2.0",
+    "@getpara/react-native-wallet": "2.3.0",
+    "@getpara/viem-v2-integration": "2.3.0",
     "@peculiar/webcrypto": "^1.5.0",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-navigation/native": "^7.1.6",

--- a/mobile/with-expo-one-click-login/yarn.lock
+++ b/mobile/with-expo-one-click-login/yarn.lock
@@ -2023,47 +2023,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@getpara/core-sdk@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@getpara/core-sdk@npm:2.0.0"
+"@getpara/core-sdk@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@getpara/core-sdk@npm:2.3.0"
   dependencies:
     "@celo/utils": "npm:^8.0.2"
     "@cosmjs/encoding": "npm:^0.32.4"
     "@ethereumjs/util": "npm:^9.1.0"
-    "@getpara/user-management-client": "npm:2.0.0"
+    "@getpara/user-management-client": "npm:2.3.0"
     "@noble/hashes": "npm:^1.5.0"
     base64url: "npm:^3.0.1"
     libphonenumber-js: "npm:^1.11.7"
     node-forge: "npm:^1.3.1"
     uuid: "npm:^11.1.0"
-  checksum: 10/22c06fbce539ce18bfc0ea401dee076649e7b14000c4c90fcd8d858ccb363efe24c14137a899151c8af6662dbe383471e50f4052b9011745597b8fca13001e3b
+  checksum: 10/3dce85d4c17702d14fa5948ef2a8631b098ca5e8d224762bc5dae1b4dfb48fc79fe0f84075daeae67e97e15b0d487348caed715e95a3a434def546b792543328
   languageName: node
   linkType: hard
 
-"@getpara/core-sdk@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@getpara/core-sdk@npm:2.1.0"
+"@getpara/react-native-wallet@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@getpara/react-native-wallet@npm:2.3.0"
   dependencies:
-    "@celo/utils": "npm:^8.0.2"
-    "@cosmjs/encoding": "npm:^0.32.4"
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@getpara/user-management-client": "npm:2.1.0"
-    "@noble/hashes": "npm:^1.5.0"
-    base64url: "npm:^3.0.1"
-    libphonenumber-js: "npm:^1.11.7"
-    node-forge: "npm:^1.3.1"
-    uuid: "npm:^11.1.0"
-  checksum: 10/f956826ec20897c8eb0cd0264fd2267f7cf4a9705f7e3a48f3acff0fb1ca894615b6af19473c8855b1a1171bd031693cdaac5fb4c978809d2e73d071b8093273
-  languageName: node
-  linkType: hard
-
-"@getpara/react-native-wallet@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@getpara/react-native-wallet@npm:2.1.0"
-  dependencies:
-    "@getpara/core-sdk": "npm:2.1.0"
-    "@getpara/user-management-client": "npm:2.1.0"
-    "@getpara/web-sdk": "npm:2.1.0"
+    "@getpara/core-sdk": "npm:2.3.0"
+    "@getpara/user-management-client": "npm:2.3.0"
+    "@getpara/web-sdk": "npm:2.3.0"
     "@peculiar/webcrypto": "npm:^1.5.0"
     "@ungap/structured-clone": "npm:1.3.0"
     react-native-url-polyfill: "npm:2.0.0"
@@ -2079,56 +2062,45 @@ __metadata:
     react-native-quick-base64: "*"
     react-native-quick-crypto: "*"
     readable-stream: "*"
-  checksum: 10/94c035d47b895ec3c22e6372f37e1ca9080216ca25cfda15fa00e597663d2256a63bd0382de7cb00e40bbedd9b5d330b0d350ad08da0240f0ea37c17a646e7be
+  checksum: 10/65579332a3ec27039f0d2ee716b1ef342540e35b1eca4b4fa256d2ede0d4fa49305559a25851d96f1fdd1c2836bcf6a7d6ddecbc4f581d32a5335c297e9d8646
   languageName: node
   linkType: hard
 
-"@getpara/shared@npm:1.8.0":
-  version: 1.8.0
-  resolution: "@getpara/shared@npm:1.8.0"
-  checksum: 10/6fe4cfb10af55b49dc093a8229da5c31a0f107036c7577c7fdda6b6ebd120dbc4d3c9e54d32515bb03494c9b19a0de6bbc69cf38b9c1bf9a3ee72689520055f1
+"@getpara/shared@npm:1.9.0":
+  version: 1.9.0
+  resolution: "@getpara/shared@npm:1.9.0"
+  checksum: 10/fc24bea1991469711491275f9631f007bf281b206786c84c5fca50769a6bef2594876ceee65166c399ff7af707c36fbd0ef0a604f29393748a304c3292509b1e
   languageName: node
   linkType: hard
 
-"@getpara/user-management-client@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@getpara/user-management-client@npm:2.0.0"
+"@getpara/user-management-client@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@getpara/user-management-client@npm:2.3.0"
   dependencies:
-    "@getpara/shared": "npm:1.8.0"
+    "@getpara/shared": "npm:1.9.0"
     axios: "npm:^1.8.4"
     libphonenumber-js: "npm:^1.11.7"
-  checksum: 10/57d3dc57b0e91dff133a6893ffe237a7b341bbc951b6c32240eb732a2c2c3f9844643912e264a007399353803f19a9e1b94b9cc4506f827bbc39283786a64893
+  checksum: 10/772b5458a7b8e1ea61217386caf15684a83bf07b765c8c4a0c362ae6a3d5bad14fe9a02165353b446977175512c7e72bc5cdb3b78f76e586db1f426f9548cd8c
   languageName: node
   linkType: hard
 
-"@getpara/user-management-client@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@getpara/user-management-client@npm:2.1.0"
+"@getpara/viem-v2-integration@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@getpara/viem-v2-integration@npm:2.3.0"
   dependencies:
-    "@getpara/shared": "npm:1.8.0"
-    axios: "npm:^1.8.4"
-    libphonenumber-js: "npm:^1.11.7"
-  checksum: 10/f5ad6b51e2c2286c123661cc7620fd031d6c4d83a98cb6419c9fc9b4ec67d0f9d99615339b4574b153bb5b7b402f2e39714e56097a928a7be00614f82c7dd64c
-  languageName: node
-  linkType: hard
-
-"@getpara/viem-v2-integration@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@getpara/viem-v2-integration@npm:2.0.0"
-  dependencies:
-    "@getpara/core-sdk": "npm:2.0.0"
+    "@getpara/core-sdk": "npm:2.3.0"
   peerDependencies:
     viem: 2.x
-  checksum: 10/19a464bc1feab479987583f1a32e758aa8dcda3860139b7d9e647fdc289f3e63b611c6c20130969accadeade69cfba4985d1016256e7b951ee8a69f25e93ec89
+  checksum: 10/4ae31003fb5e4d721ac0f4228f51345e92a8467d0ed6ac350ff75dd8acc357dae9504f044de6d32bbb6f11b9e28dea5bb536196cf46045f12d0ca3646d07d05e
   languageName: node
   linkType: hard
 
-"@getpara/web-sdk@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@getpara/web-sdk@npm:2.1.0"
+"@getpara/web-sdk@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@getpara/web-sdk@npm:2.3.0"
   dependencies:
-    "@getpara/core-sdk": "npm:2.1.0"
-    "@getpara/user-management-client": "npm:2.1.0"
+    "@getpara/core-sdk": "npm:2.3.0"
+    "@getpara/user-management-client": "npm:2.3.0"
     base64url: "npm:^3.0.1"
     buffer: "npm:6.0.3"
     cbor-web: "npm:^9.0.2"
@@ -2139,7 +2111,7 @@ __metadata:
   peerDependenciesMeta:
     "@farcaster/miniapp-sdk":
       optional: true
-  checksum: 10/5305da390adac3ef63d7957b7246103afe991d18581cd3851cb384dcc0db856771ca36af8515477bda0b1c94939469c5e953320c642353ea211d9df2f2392d58
+  checksum: 10/eb686b2d8c47b25914ef87c22aa603f7bbce2056b6f151c6798656cfc62b973c3e548370491084bb08672cc8faaacd885bb1bf4d4e7d7fea18ca4d33a90c60ef
   languageName: node
   linkType: hard
 
@@ -12057,8 +12029,8 @@ __metadata:
     "@babel/core": "npm:^7.20.0"
     "@craftzdog/react-native-buffer": "npm:^6.1.0"
     "@expo/vector-icons": "npm:^15.0.2"
-    "@getpara/react-native-wallet": "npm:2.1.0"
-    "@getpara/viem-v2-integration": "npm:2.0.0"
+    "@getpara/react-native-wallet": "npm:2.3.0"
+    "@getpara/viem-v2-integration": "npm:2.3.0"
     "@peculiar/webcrypto": "npm:^1.5.0"
     "@react-native-async-storage/async-storage": "npm:^2.2.0"
     "@react-navigation/native": "npm:^7.1.6"


### PR DESCRIPTION
Bumps Para React Native wallet and related SDK packages to 2.3.0 in the Expo one-click login example. Updates yarn.lock and Podfile.lock to keep JS/native dependencies aligned. Adjusts the Xcode project object version for CocoaPods compatibility.