### PR TITLE
fix: update REST example for flat wallet response format (ENG-6410)

### DIFF
--- a/server/rest-with-node/src/index.ts
+++ b/server/rest-with-node/src/index.ts
@@ -17,25 +17,23 @@ if (!PARA_API_KEY) {
 
 type WalletType = 'EVM' | 'SOLANA' | 'COSMOS';
 
+type WalletScheme = 'DKLS' | 'CGGMP' | 'ED25519';
+
 type Wallet = {
   id: string;
   type: WalletType;
+  scheme: WalletScheme;
   status: 'creating' | 'ready' | 'error';
   address?: string;
   publicKey?: string;
   createdAt: string;
 };
 
-type CreateWalletResponse = {
-  wallet: Wallet;
-  scheme: 'DKLS' | 'CGGMP' | 'ED25519';
-};
-
 type CreateWalletBody = {
   type: WalletType;
   userIdentifier: string;
   userIdentifierType: string;
-  scheme?: CreateWalletResponse['scheme'];
+  scheme?: WalletScheme;
   cosmosPrefix?: string;
 };
 
@@ -108,11 +106,11 @@ app.post('/rest/wallets', async (req: Request<unknown, unknown, CreateWalletBody
   }
 
   try {
-    const result = await callPara<CreateWalletResponse>('/v1/wallets', {
+    const wallet = await callPara<Wallet>('/v1/wallets', {
       method: 'POST',
       body: { type, userIdentifier, userIdentifierType, scheme, cosmosPrefix },
     });
-    res.status(201).json(result);
+    res.status(201).json(wallet);
   } catch (error) {
     handleError(res, error);
   }


### PR DESCRIPTION
## Summary

- Updated `Wallet` type to include `scheme` field
- Removed `CreateWalletResponse` wrapper type — POST /v1/wallets now returns a flat `Wallet` object
- Updated POST call site to use `Wallet` type directly

Companion to [user-management#681](https://github.com/capsule-org/user-management/pull/681) which flattened the response format.

## Test plan

- [x] Types match the updated OpenAPI spec and server implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)