### PR TITLE
feat: add wallet lookup by identifier to REST example

### DIFF
--- a/server/rest-with-node/src/index.ts
+++ b/server/rest-with-node/src/index.ts
@@ -116,6 +116,23 @@ app.post('/rest/wallets', async (req: Request<unknown, unknown, CreateWalletBody
   }
 });
 
+app.get('/rest/wallets', async (req: Request, res: Response) => {
+  const { userIdentifier, userIdentifierType } = req.query;
+
+  if (!userIdentifier || !userIdentifierType) {
+    return res.status(400).json({ error: 'userIdentifier and userIdentifierType query params are required' });
+  }
+
+  try {
+    const result = await callPara<{ data: Wallet[] }>(
+      `/v1/wallets?userIdentifier=${encodeURIComponent(String(userIdentifier))}&userIdentifierType=${encodeURIComponent(String(userIdentifierType))}`,
+    );
+    res.json(result);
+  } catch (error) {
+    handleError(res, error);
+  }
+});
+
 app.get('/rest/wallets/:walletId', async (req: Request, res: Response) => {
   try {
     const wallet = await callPara<Wallet>(`/v1/wallets/${req.params.walletId}`);


### PR DESCRIPTION
## Summary
- Adds a `GET /rest/wallets` route to the Node REST example that proxies to the new `GET /v1/wallets` endpoint
- Accepts `userIdentifier` and `userIdentifierType` query params to look up wallets by user identifier
- Placed between the existing `POST /rest/wallets` (create) and `GET /rest/wallets/:walletId` (get by ID) routes

Ref: ENG-6408

## Test plan
- [x] Start the REST example server (`yarn dev`)
- [x] Call `GET /rest/wallets?userIdentifier=test@test.getpara.com&userIdentifierType=EMAIL` and verify it returns wallet data
- [x] Verify missing query params return a 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)