### PR TITLE
feat: support list wallets filters and pagination in REST example

### DIFF
--- a/server/rest-with-node/src/index.ts
+++ b/server/rest-with-node/src/index.ts
@@ -117,15 +117,15 @@ app.post('/rest/wallets', async (req: Request<unknown, unknown, CreateWalletBody
 });
 
 app.get('/rest/wallets', async (req: Request, res: Response) => {
-  const { userIdentifier, userIdentifierType } = req.query;
-
-  if (!userIdentifier || !userIdentifierType) {
-    return res.status(400).json({ error: 'userIdentifier and userIdentifierType query params are required' });
+  const params = new URLSearchParams();
+  for (const key of ['userIdentifier', 'userIdentifierType', 'type', 'status', 'address', 'limit', 'cursor']) {
+    if (req.query[key]) params.set(key, String(req.query[key]));
   }
 
   try {
-    const result = await callPara<{ data: Wallet[] }>(
-      `/v1/wallets?userIdentifier=${encodeURIComponent(String(userIdentifier))}&userIdentifierType=${encodeURIComponent(String(userIdentifierType))}`,
+    const qs = params.toString();
+    const result = await callPara<{ data: Wallet[]; pagination: { cursor: string | null; hasMore: boolean; limit: number } }>(
+      `/v1/wallets${qs ? `?${qs}` : ''}`,
     );
     res.json(result);
   } catch (error) {

--- a/server/rest-with-node/src/index.ts
+++ b/server/rest-with-node/src/index.ts
@@ -119,7 +119,7 @@ app.post('/rest/wallets', async (req: Request<unknown, unknown, CreateWalletBody
 app.get('/rest/wallets', async (req: Request, res: Response) => {
   const params = new URLSearchParams();
   for (const key of ['userIdentifier', 'userIdentifierType', 'type', 'status', 'address', 'limit', 'cursor']) {
-    if (req.query[key]) params.set(key, String(req.query[key]));
+    if (req.query[key] != null) params.set(key, String(req.query[key]));
   }
 
   try {


### PR DESCRIPTION
## Summary
- Updated `GET /rest/wallets` to support all new filter params (`type`, `status`, `address`, `limit`, `cursor`)
- No longer requires `userIdentifier`+`userIdentifierType` — can list all wallets

## Changes
- `server/rest-with-node/src/index.ts` — pass through optional query params, return paginated response type

## Test plan
- [x] TypeScript compiles
- [x] Endpoint works with/without filters

Relates to ENG-6420

🤖 Generated with [Claude Code](https://claude.com/claude-code)