### PR TITLE
chore: fix hardcoded paths in CLAUDE.md files

### DIFF
--- a/mobile/with-flutter/CLAUDE.md
+++ b/mobile/with-flutter/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Build iOS: `flutter build ios`
 - Format code: `flutter format .`
 - **Lint code: `flutter analyze`** (REQUIRED: Always run and fix issues before completing tasks)
-- Run on iOS simulator: `cd ~/para/examples-hub/mobile/with-flutter && flutter run -d C30E9754-F295-4A90-A70F-63DFE3F53DB8`
+- Run on iOS simulator: `flutter run` (uses default booted simulator)
 - Run tests: `flutter test`
 - Run single test: `flutter test test/path_to_test.dart`
 - E2E test setup: `cd test_e2e && dart run tool/setup.dart`

--- a/mobile/with-swift/CLAUDE.md
+++ b/mobile/with-swift/CLAUDE.md
@@ -7,14 +7,13 @@ This directory contains an example Swift app that showcases how to use Para's Sw
 
 ## 1. Build Commands
 
-> **Note:** The main Xcode workspace lives one level above this folder at `~/para/Para.xcworkspace`. That workspace includes both `swift-sdk` and the example app.
+> **Note:** The Xcode workspace (`ParaSwift.xcworkspace`) lives at the root of the para directory. It includes both `swift-sdk` and the example app.
 
-### Build the iOS app for iOS 16.5
+### Build the iOS app
 
 ```bash
-cd ~/para
 xcodebuild \
-  -workspace ParaSwift.xcworkspace \
+  -workspace ../../../ParaSwift.xcworkspace \
   -scheme Example \
   -sdk iphonesimulator \
   -configuration Release \
@@ -24,7 +23,6 @@ xcodebuild \
 ### Format and Lint
 
 ```bash
-cd ~/para/examples-hub/mobile/with-swift/
 swiftformat --swiftversion 6.1 .
 ```
 > Run `swiftformat` before committing.
@@ -34,28 +32,25 @@ swiftformat --swiftversion 6.1 .
 ## 2. End-to-End (E2E) Tests
 > Note: There are no unit tests for the sample app. E2E tests are preferred (see below).
 
-> **Location:**  
-> All E2E/XCTest UI tests for the iOS example app live under
-> `~/para/examples-hub/mobile/with-swift/exampleUITests`.
+> **Location:**
+> All E2E/XCTest UI tests live under `exampleUITests/` in this directory.
 
-To run them from the root workspace:
+To run them from the parent workspace:
 
-1. **Run every E2E test**  
+1. **Run every E2E test**
    ```bash
-   cd ~/para
    xcodebuild \
-     -workspace ParaSwift.xcworkspace \
+     -workspace ../../../ParaSwift.xcworkspace \
      -scheme Example \
      -sdk iphonesimulator \
      -destination "platform=iOS Simulator,name=iPhone 16 Pro" \
      test
    ```
 
-2. **Run a single E2E test method**  
+2. **Run a single E2E test method**
    ```bash
-   cd ~/para
    xcodebuild \
-     -workspace ParaSwift.xcworkspace \
+     -workspace ../../../ParaSwift.xcworkspace \
      -scheme Example \
      -sdk iphonesimulator \
      -destination "platform=iOS Simulator,name=iPhone 16 Pro" \


### PR DESCRIPTION
## Summary
- Remove `~/para` hardcoded paths, use relative paths instead
- Remove hardcoded simulator UUID from flutter example
- These CLAUDE.md files are used by Claude Code and should work regardless of clone location

## Test plan
- [x] Path references are accurate

NO DOCS NEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)