### PR TITLE
feat: accept Solana transactions in rest-with-node sign-transaction (ENG-6721)

### DIFF
--- a/server/rest-with-node/src/index.ts
+++ b/server/rest-with-node/src/index.ts
@@ -183,12 +183,22 @@ app.post(
   async (req: Request<{ walletId: string }>, res: Response) => {
     const { transaction } = req.body;
 
-    if (!transaction || typeof transaction !== 'object' || Array.isArray(transaction)) {
-      return res.status(400).json({ error: 'transaction object is required' });
+    // EVM: transaction is an object with { to, chainId, ... }.
+    // Solana: transaction is a base64-encoded string. Both legacy `Transaction` and
+    // v0 `VersionedTransaction` (with Address Lookup Tables) are accepted — the REST
+    // API auto-detects the format.
+    const isEvm = transaction && typeof transaction === 'object' && !Array.isArray(transaction);
+    const isSolana = typeof transaction === 'string' && transaction.length > 0;
+
+    if (!isEvm && !isSolana) {
+      return res.status(400).json({
+        error:
+          'transaction must be an EVM object ({ to, chainId, ... }) or a base64-encoded Solana transaction string',
+      });
     }
 
-    if (!transaction.to || !transaction.chainId) {
-      return res.status(400).json({ error: 'transaction.to and transaction.chainId are required' });
+    if (isEvm && (!transaction.to || !transaction.chainId)) {
+      return res.status(400).json({ error: 'EVM transaction.to and transaction.chainId are required' });
     }
 
     try {


### PR DESCRIPTION
Linear: [ENG-6721](https://linear.app/capsule-labs/issue/ENG-6721/add-solana-versionedtransaction-v0-support-to-rest-sign-transaction)

## Summary

Extends the `/rest/wallets/:walletId/sign-transaction` proxy route in the `rest-with-node` example to accept base64-encoded Solana transactions in addition to the existing EVM object shape.

Both legacy `Transaction` and v0 `VersionedTransaction` (with Address Lookup Tables) are accepted — the upstream REST API auto-detects the format, so the example simply forwards whatever base64 string the caller provides.

## Companion PRs

- user-management [#791](https://github.com/capsule-org/user-management/pull/791) — the actual REST API change
- docs-mintlify [#383](https://github.com/capsule-org/docs-mintlify/pull/383) — OpenAPI + setup.mdx callout

## Test plan

- [x] `yarn typecheck` passes
- [x] EVM path preserved — still requires `transaction.to` + `transaction.chainId` and still returns the same 400 otherwise
- [x] New Solana path accepts any non-empty base64 string and forwards to the REST API unchanged
- [ ] Manual smoke test against sandbox with a real Solana wallet (deferred — run post-merge)

NO DOCS NEEDED